### PR TITLE
AdBreak Small Fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", ">= 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.0)
+    activesupport (7.2.2.2)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -13,7 +13,6 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
@@ -279,7 +278,7 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (1.8.0)
     uri (1.0.2)
-    wdm (0.1.1)
+    wdm (0.2.0)
     webrick (1.9.0)
 
 PLATFORMS
@@ -292,7 +291,7 @@ DEPENDENCIES
   just-the-docs
   tzinfo (>= 1, < 3)
   tzinfo-data
-  wdm (~> 0.1.1)
+  wdm (>= 0.2.0)
   webrick (~> 1.8)
 
 BUNDLED WITH

--- a/jailbreaking/AdBreak/index.md
+++ b/jailbreaking/AdBreak/index.md
@@ -106,7 +106,7 @@ If you face any issues, please check the [troubleshooting](#troubleshooting) sec
         <div class="step">
             <h2>Jailbreak!</h2>
             <div class="stepContent">
-                <p>Unplug, click on an ad and go through the popups, once you click OK on "Bang!", the jailbreak script should run.</p>
+                <p>Unplug, click on an ad and go through the popups, once you click Close on "Bang!", the jailbreak script should run.</p>
                 <img src="./demo.png" />
             </div>
         </div>
@@ -142,11 +142,10 @@ If you face any issues, please check the [troubleshooting](#troubleshooting) sec
 ### FAQ
 
 - The JB does NOT automatically remove advertisements, see Marek's scriptlet.
-- It will never work on the KS/Kindle Scribe! Ads can NOT be re-enabled there!
+- It will never work on the KS/Kindle Scribe, or the CS/Colorsoft! Ads can NOT be re-enabled there!
 - No, this is not "UJ"/"Unnamed Jailbreak". That is separate.
+- On mass storage kindles, **if you cannot see the `system` folder**, you will have to navigate to the path manually, or follow [this](https://kb.blackbaud.com/knowledgebase/Article/41890) guide to see protected system folders. 
 - "Is there a way to make my device ad supported?" (see below)
-- It could be possible to reach adbreak by using `.active_content_sandbox` with large junk files and performing a fast restart/battery unplug before the contents get recursively deleted, or rebooting without ejecting.
-- On mass storage kindles, if you cannot see the `system` folder, you will have to navigate to the path manually, or disable "hide protected operating system files" (google it). 
 
 ### Enabling Ads
 (needed for jailbreak, safe to remove later)

--- a/models.json
+++ b/models.json
@@ -1079,7 +1079,7 @@
     "last_firmware": "Not Yet Discontinued",
     "platform": "Bellatrix4",
     "board": "Seabreeze",
-    "jailbreak": "<a href=\"WinterBreak\">WinterBreak < 5.18.0.2</a><br/><br/><a href=\"AdBreak\">AdBreak 5.18.1+</a>",
+    "jailbreak": "<a href=\"WinterBreak\">WinterBreak < 5.18.0.2</a>",
     "generation_nickname": "CS",
     "nicknames": [
       "CS"


### PR DESCRIPTION
Changelog:

- Say click "Close" on the dialog and not click "OK" on the dialog
- Removed AdBreak for CS in models.json
- Further elaborated on how to show protected system folders
- Mentioned CS being unsupported in FAQ alongside KS
- Switched Gemfile to WDM 0.2.0... again? it reverted?