### PR TITLE
Fix multiple issues across the site

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -109,7 +109,7 @@ params:
             <p>Documentation for homebrew developers</p>
         </a>
 
-        <a class="card" href="http://discord.kindlemodding.org/">
+        <a class="card" href="https://discord.kindlemodding.org/">
             <h2 style="color: var(--text-colour) !important;">Discord</h2>
             <p>Join our Discord</p>
         </a>

--- a/content/jailbreaking/AdBreak/__index.md
+++ b/content/jailbreaking/AdBreak/__index.md
@@ -56,28 +56,28 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
             <h2>Aeroplane Mode</h2>
             <div class="stepContent">
                 <p>Once you have verified ads are displayed on the lockscreen, enable airplane mode.</p>
-                <img src="./airplane_mode.png" /> 
+                <img src="./airplane_mode.png" alt="Screenshot showing Airplane mode toggle in Kindle settings" />
             </div>
         </div>
         <div class="step">
             <h2>View all ads</h2>
             <div class="stepContent">
                 <p>Click on the top right menu and select "View all ads", which should display multiple "special offers".</p>
-                <img src="./view_ads.png" />
+                <img src="./view_ads.png" alt="Kindle menu showing View all ads option" />
             </div>
         </div>
         <div class="step">
             <h2>Copy .assets</h2>
             <div class="stepContent">
                 <p>Plug in the Kindle, open the system folder and copy the ".assets" folder to your computer.</p>
-                <img src="./copy_assets.png" />
+                <img src="./copy_assets.png" alt="File explorer showing .assets folder in Kindle system directory" />
             </div>
         </div>
         <div class="step">
             <h2>Unzip AdBreak</h2>
             <div class="stepContent">
                 <p>Unzip the previously downloaded AdBreak, and place the extracted contents within the ".assets" folder located on your computer.</p>
-                <img src="./copy_adbreak.png" />
+                <img src="./copy_adbreak.png" alt="File explorer showing AdBreak files copied into .assets folder" />
             </div>
         </div>
         <div class="step">
@@ -91,14 +91,14 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
                     <p class="version-label">MacOS/Linux:</p>
                     <p>Run <code> find . -name 'details.html' -exec cp adbreak.html {} \;</code> using a terminal.</p>
                 </div>
-                <img src="./replacer.png" />
+                <img src="./replacer.png" alt="Terminal window running the replace script" />
             </div>
         </div>
         <div class="step">
             <h2>Replace Kindle .assets</h2>
             <div class="stepContent">
                 <p>Delete the original kindle <code>.assets</code> and replace it with your on-PC modified copy.</p>
-                <img src="./replace_old_assets.png" />
+                <img src="./replace_old_assets.png" alt="File explorer showing modified .assets folder being copied to Kindle" />
             </div>
         </div>
         <div class="step">
@@ -108,7 +108,7 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
                 <p class="note">
                     You can safely ignore any "application error" popups, they are irrelevant.
                 </p>
-                <img src="./demo.png" />
+                <img src="./demo.png" alt="Kindle screen showing AdBreak jailbreak demonstration with Bang! popup" />
             </div>
         </div>
     </div>

--- a/content/jailbreaking/WinterBreak/__index.md
+++ b/content/jailbreaking/WinterBreak/__index.md
@@ -62,25 +62,25 @@ It is based on [Mesquito](../../mesquito/)
             <h2>Airplane Mode</h2>
             <div class="stepContent">
                 <p>Turn on Airplane mode on your Kindle</p>
-                <img src="./airplane_mode.png" /> 
+                <img src="./airplane_mode.png" alt="Screenshot showing Airplane mode toggle in Kindle settings" />
             </div>
         </div>
         <div class="step">
             <h2>Rebooting</h2>
             <div class="stepContent">
                 <p>Reboot your Kindle</p>
-                <img src="./reboot.png" />
+                <img src="./reboot.png" alt="Screenshot showing the reboot option in Kindle menu" />
             </div>
         </div>
         <div class="step">
             <h2>Extracting WinterBreak</h2>
             <div class="stepContent">
                 <p>Once it has booted, plug the Kindle into your computer and extract the contents of the <code>WinterBreak.tar.gz</code> file to a safe place on your computer</p>
-                <p>Then copy the files to your Kindle (do not extract direcly to the Kindle as this may fail). Replace any files if you are prompted to</p>
+                <p>Then copy the files to your Kindle (do not extract directly to the Kindle as this may fail). Replace any files if you are prompted to</p>
                 <p class="highlight">
                     For Linux/MacOS users, ENSURE the hidden folder <code>.active_content_sandbox</code> has been copied to your Kindle
                 </p>
-                <img src="./file_list.png" />
+                <img src="./file_list.png" alt="File explorer showing WinterBreak files copied to Kindle root directory" />
             </div>
         </div>
 <div class="step">
@@ -89,14 +89,14 @@ It is based on [Mesquito](../../mesquito/)
                 <p>Eject the Kindle from your computer</p>
                 <p>Open the Kindle Store on your Kindle by clicking on the cart icon on the home screen</p>
                 <p>When prompted, click <code>Yes</code> to turn off Airplane mode</p>
-                <img src="./store_aeroplane.png" />
+                <img src="./store_aeroplane.png" alt="Kindle Store prompt asking to turn off Airplane mode" />
             </div>
         </div>
         <div class="step">
             <h2>Running WinterBreak</h2>
             <div class="stepContent">
                 <p>Once Mesquito has loaded, click on the WinterBreak icon</p>
-                <img src="./winterbreak_launcher.png" />
+                <img src="./winterbreak_launcher.png" alt="Mesquito loader interface showing WinterBreak icon" />
             </div>
         </div>
         <div class="step">
@@ -108,7 +108,7 @@ It is based on [Mesquito](../../mesquito/)
                 <p class="warning">
                     If present, delete the <code>update.bin.tmp.partial</code> file from your device to prevent an automatic update
                 </p>
-                <img src="./winterbreak_run.png" />
+                <img src="./winterbreak_run.png" alt="Kindle screen showing WinterBreak jailbreak success message" />
             </div>
         </div>
     </div>

--- a/content/jailbreaking/_index.md
+++ b/content/jailbreaking/_index.md
@@ -19,7 +19,7 @@ As a user, this gives you access to:
 
 > [!WARNING]
 > Please be aware of the risks of jailbreaking before you jailbreak your Kindle including, but not limited to:
-> - Potentially voiding the Kindle's waranty
+> - Potentially voiding the Kindle's warranty
 > - Bricking (permanently breaking) the device
 > - Security Risks
 

--- a/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
+++ b/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
@@ -37,7 +37,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
             <div class="stepContent">
             <p>Extract the contents of the MRPI tar file you downloaded, and copy the <code>extensions</code> and <code>mrpackages</code> folders to your Kindle</p>
             <br/>
-            <img src="./mrpackages_extensions_folders.png" />
+            <img src="./mrpackages_extensions_folders.png" alt="File explorer showing mrpackages and extensions folders copied to Kindle" />
             </div>
         </div>
         <div class="step">
@@ -48,13 +48,13 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
                 <br/>
                 <p>Now, find the <code>Update_KUALBooklet_*_install.bin</code> file and copy it to your Kindle's <code>mrpackages</code> folder</p>
                 <br/>
-                <img src="./kual_install_bin.png" />
+                <img src="./kual_install_bin.png" alt="File explorer showing KUAL install file in mrpackages folder" />
             </div>
         </div>
         <div class="step">
             <h2>Eject and unplug your Kindle</h2>
             <div class="stepContent">
-                <img src="./eject.png" />
+                <img src="./eject.png" alt="Operating system eject dialog for Kindle device" />
             </div>
         </div>
         <div class="step">
@@ -62,7 +62,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
             <div class="stepContent">
                 <p>On your Kindle, type <code>;log mrpi</code> into the search bar and hit enter</p>
                 <br/>
-                <img src="./run_dispatch.png" />
+                <img src="./run_dispatch.png" alt="Kindle search bar with ;log mrpi command entered" />
             </div>
         </div>
         <div class="step">
@@ -71,7 +71,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
                 <p>Now wait whilst KUAL is installed, your Kindle screen turns white and shows some icons, after a while you will be returned to your library and see a <code>KUAL</code> book appear in it.</p>
                 <p class="highlight">If you see a "Application Error" dialog, you can close it without worry - this is normal behaviour on some modern Kindles</p>
                 <br/>
-                <img src="./success.png" />
+                <img src="./success.png" alt="Kindle library showing KUAL booklet successfully installed" />
             </div>
         </div>    
     </div>

--- a/content/jailbreaking/post-jailbreak/setting-up-a-hotfix/__index.md
+++ b/content/jailbreaking/post-jailbreak/setting-up-a-hotfix/__index.md
@@ -36,7 +36,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
                 <p class="warning">
                    If you see any other files on your Kindle ending in <code>.bin</code>, or have a similar name to <code>update.bin.tmp.partial</code>, you must delete them for the hotfix to work. <br> Remember to enable Airplane mode to prevent any automatic updates from downloading
                 </p>
-                <img src="./copy_hotfix.png" />
+                <img src="./copy_hotfix.png" alt="File explorer showing hotfix file copied to Kindle root directory" />
             </div>
         </div>
         <div class="step">
@@ -44,7 +44,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
             <div class="stepContent">
                 <p>Eject the Kindle and unplug it, then open settings, click on the three dots, and select <code>Update Your Kindle</code></p>
                 <br/>
-                <img src="./update_settings.png" />
+                <img src="./update_settings.png" alt="Kindle settings menu showing Update Your Kindle option" />
             </div>
         </div>
         <div class="step">
@@ -52,7 +52,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
             <div class="stepContent">
                 <p>If asked, select <code>Update</code>. You can expect this to install the hotfix, as an update.</p>
                 <br/>
-                <img src="./update_dialog.png" />
+                <img src="./update_dialog.png" alt="Kindle update confirmation dialog" />
             </div>
         </div>
         <div class="step">
@@ -62,7 +62,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
                 <p>Run the hotfix by selecting the <code>Run Hotfix</code> booklet in your library.</p>
                 <p>Once the hotfix is done running, you can install <code>KUAL</code> and <code>MRPI</code></p>
                 <p class="note">You will need to run the hotfix booklet after every OTA update</p>
-                <img src="./run_hotfix.png" />
+                <img src="./run_hotfix.png" alt="Kindle library showing Run Hotfix booklet" />
             </div>
         </div>
     </div>

--- a/content/jailbreaking/prevent-auto-update/__index.md
+++ b/content/jailbreaking/prevent-auto-update/__index.md
@@ -44,14 +44,14 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <h2>1. Put Your Kindle in Airplane Mode</h2>
             <div class="stepContent">
                 <p>Turn on Airplane mode on your Kindle</p>
-                <img src="../WinterBreak/airplane_mode.png" />
+                <img src="../WinterBreak/airplane_mode.png" alt="Screenshot showing Airplane mode toggle in Kindle settings" />
             </div>
         </div>
         <div class="step">
             <h2>2. Connect Your Kindle to Your Computer via USB</h2>
             <div class="stepContent">
                 <p>Use a USB cable to connect your Kindle to your computer.</p>
-                <img src="./usb-mode.png"/>
+                <img src="./usb-mode.png" alt="Kindle displaying USB drive mode screen" />
                 <p>Wait for the Kindle to appear as a USB drive.</p>
             </div>
         </div>
@@ -59,7 +59,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <h2>3. Download the Disk Filler Script</h2>
             <div class="stepContent">
                 <p>Go to the <a href="https://github.com/bastianmarin/Kindle-Filler-Disk/">Kindle-Filler-Disk GitHub repository</a>.</p>
-                <img src="./github-files.png"/>
+                <img src="./github-files.png" alt="GitHub repository page showing Filler script files" />
                 <p>Download the appropriate script for your operating system:</p>
                 <div style="margin-left:2em">
                     <span><strong>Windows:</strong> <code>Filler.ps1</code></span><br/>
@@ -71,7 +71,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <h2>4. Move the Script to Your Kindle</h2>
             <div class="stepContent">
                 <p>Copy the downloaded script file to the root directory of your Kindle (the main folder you see when you open the Kindle as a USB drive).</p>
-                <img src="./root-main.png"/>
+                <img src="./root-main.png" alt="File explorer showing Filler script in Kindle root directory" />
                 <span><strong>Windows:</strong> <code>Filler.ps1</code></span><br/>
                 <span><strong>macOS/Linux:</strong> <code>Filler.sh</code></span>
             </div>
@@ -94,7 +94,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
                     <p>Run the script:</p>
                     <pre><code>./Filler.sh</code></pre>
                 </div>
-                <img src="./run-script.png"/>
+                <img src="./run-script.png" alt="Terminal window showing Filler script execution" />
               </div>     
             </div>
         <div class="step">
@@ -103,7 +103,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
                 <p>Eject your Kindle from your computer.</p>
                 <p>On your Kindle, go to <strong>Settings &gt; Device Options &gt; Device Info</strong> (or similar).</p>
                 <p>Check that the available storage is <strong>20-90 MB or less</strong>.</p>
-                <img src="./final.png"/>
+                <img src="./final.png" alt="Kindle device info screen showing limited available storage" />
             </div>
         </div>
         <div class="step">

--- a/content/kindle-apps-and-services/com.lab126.scanner/extractors.md
+++ b/content/kindle-apps-and-services/com.lab126.scanner/extractors.md
@@ -98,7 +98,7 @@ The `handler` is a function that takes a pointer to a `scanner_event` object
 The `SCANNER_ADD` event type is the most important event, it is triggered when the scanner detects a new file in the userstore.  
 
 
-For example, when `Kterm.sh` is copied to `/mnt/us`, the `sh_integration` extractor recieves the following `scanner_event`
+For example, when `Kterm.sh` is copied to `/mnt/us`, the `sh_integration` extractor receives the following `scanner_event`
 
 ```c
 .event_type=0

--- a/content/kindle-dev/awesome-window-manager/__index.md
+++ b/content/kindle-dev/awesome-window-manager/__index.md
@@ -21,7 +21,7 @@ For example, the Kindle store has a window title of:
 L:A_N:application_PC:TS_ID:com.lab126.store
 ```
 
-Window titles are actually a key-value store, seperated by an `_` character, this means the above title, would translate roughly to pseudo-JSON as:
+Window titles are actually a key-value store, separated by an `_` character, this means the above title, would translate roughly to pseudo-JSON as:
 ```json
 {
     "L":"A",

--- a/content/wafs-and-mesquite/the-kindle-object/kindle-messaging.md
+++ b/content/wafs-and-mesquite/the-kindle-object/kindle-messaging.md
@@ -33,13 +33,13 @@ Sends a message through the Kindle's internal LIPC messaging system, `message` i
 | eventType | switchViewMode | String | The event to send                                       |
 | eventData | fullscreen     | String | The data sent with the corresponding event              |
 
-## kindle.messaging.recieveMessage
+## kindle.messaging.receiveMessage
 ~~~js
-kindle.messaging.recieveMessage(eventType, callback)
+kindle.messaging.receiveMessage(eventType, callback)
 ~~~
 Registers a `callback` function for a specific `eventType` if a LIPC message is sent to the WAF.
 
-The `callback` recieves a `property` and `json` (or `string`) argument, ie:
+The `callback` receives a `property` and `json` (or `string`) argument, ie:
 ~~~js
 callback(property, json)
 ~~~

--- a/content/wafs-and-mesquite/the-kindle-object/kindle-net.md
+++ b/content/wafs-and-mesquite/the-kindle-object/kindle-net.md
@@ -47,7 +47,7 @@ kindle.net.confirmSSLException(confirm, callback)
 ~~~
 Method for handling an invalid SSL certificate
 
-Accepts/Cancels last invalid certificate exception recieved depending on argument `confirm` whether it is `'yes'` or `'no'`.
+Accepts/Cancels last invalid certificate exception received depending on argument `confirm` whether it is `'yes'` or `'no'`.
 
 Callback method is optional, it is unknown if any parameters are passed to it.
 
@@ -83,7 +83,7 @@ kindle.net.registerHttpErrorListener(onHttpError)
 ~~~
 
 Registers a callback for http errors.
-The `onHttpError` function will recieve the following arguments:
+The `onHttpError` function will receive the following arguments:
 
 | Name            | Description                                                                                             |
 |-----------------|---------------------------------------------------------------------------------------------------------|

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -62,7 +62,7 @@
             }
         }
 
-        themes = ["light", "dark"]
+        const themes = ["light", "dark"]
         if (!themes.includes(localStorage.getItem("theme")))
         {
             localStorage.setItem("theme", "dark");
@@ -74,7 +74,7 @@
             if (document.startViewTransition)
             {
                 document.startViewTransition(() => {
-                    refreshTheme();;
+                    refreshTheme();
                 });
             }
             else

--- a/static/assets/css/fluent_guide.css
+++ b/static/assets/css/fluent_guide.css
@@ -21,7 +21,6 @@
 
 .stepwrapper {
     width: 100%;
-    border-radius: 50px;
     border-radius: 15px;
 
     display: flex;

--- a/static/assets/css/global.css
+++ b/static/assets/css/global.css
@@ -6,7 +6,6 @@ html
     --code-background-colour: #EEE;
     --text-colour: #000;
 
-    --heading-colour: #333;
     --card-bottom-shadow-colour: #b3b3b3;
 
     --heading-colour: #000;
@@ -282,7 +281,7 @@ hr
 .navbar > a, .navbar details > summary, .navbar details > div > a
 {
     padding: 0.5em;
-    transition: background-colour 0.5s;
+    transition: background-color 0.5s;
     background-color: var(--background-colour);
 }
 
@@ -337,6 +336,21 @@ button:hover, .button:hover, .btn:hover
     box-shadow: 0px 0px 20px 2px var(--card-bottom-shadow-colour);
 }
 
+.btn-orange
+{
+    background-color: #ff8c00;
+}
+
+.btn-green
+{
+    background-color: #28a745;
+}
+
+.btn-purple
+{
+    background-color: #6f42c1;
+}
+
 code
 {
     font-family: 'Courier New', Courier, monospace;
@@ -377,6 +391,11 @@ blockquote, .note, .warning, .info
 }
 
 .info
+{
+    background: var(--highlight-colour) !important;
+}
+
+.highlight
 {
     background: var(--highlight-colour) !important;
 }

--- a/static/modelFinder.js
+++ b/static/modelFinder.js
@@ -29,7 +29,7 @@ function getSerialInfo(serial) {
 
 
 function searchForSerial() {
-    serialNumber = document.getElementById("serialNumber").value;
+    let serialNumber = document.getElementById("serialNumber").value;
     // First remove any spaces in the serial number and make it uppercase
     serialNumber = serialNumber.toUpperCase().replaceAll(' ', '');
     console.log("Searching for", serialNumber);
@@ -40,6 +40,7 @@ function searchForSerial() {
     searchStatus.innerText = "";
 
     // Validate serial number
+    let serialInfo;
     if (serialNumber.length == 2 || serialNumber.length == 3) { // Allow developers to search device codes directly
         serialInfo = {
             serial_version: serialNumber.length == 2 ? 0 : 1, // Kinda messy but it works


### PR DESCRIPTION
- Fix spelling errors: warranty, receive/receives, separated, directly
- Fix CSS: remove duplicate border-radius and --heading-colour, fix transition property
- Add missing CSS classes: .highlight, .btn-orange, .btn-green, .btn-purple
- Fix JavaScript: add variable declarations (const/let), remove double semicolon
- Add alt attributes to all images in jailbreaking guides for accessibility
- Change HTTP to HTTPS for Discord link