### PR TITLE
Remove extraneous text from Markdown content pages

### DIFF
--- a/content/firmware-and-flashing/downgrading/__index.md
+++ b/content/firmware-and-flashing/downgrading/__index.md
@@ -54,7 +54,7 @@ Congratulations! Your Kindle has been downgraded.
 
 After downgrading, you will need to re-do the post-jailbreak instructions:
 
-[Setting Up A Hotfix](../../jailbreaking/post-jailbreak/setting-up-a-hotfix/){: .button .button-purple}
+[Setting Up A Hotfix](../../jailbreaking/post-jailbreak/setting-up-a-hotfix/)
 
 
 ## Credits

--- a/content/jailbreaking/Legacy/KindleBreak/__index.md
+++ b/content/jailbreaking/Legacy/KindleBreak/__index.md
@@ -31,7 +31,7 @@ slug: index
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/LanguageBreak.md
+++ b/content/jailbreaking/Legacy/LanguageBreak.md
@@ -70,7 +70,7 @@ weight: 1
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../post-jailbreak/)
 
 # Troubleshooting
 If you had any issue with the above steps...

--- a/content/jailbreaking/Legacy/Popcorn/KT2.md
+++ b/content/jailbreaking/Legacy/Popcorn/KT2.md
@@ -25,7 +25,7 @@ On Windows, simply locate the folder you extracted earlier, double click on `MFG
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Linux
 On Linux, open a new terminal and navigate to the folder which contains the folder named `imx_usb_loader`
@@ -38,7 +38,7 @@ And wait for it to complete.
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/Popcorn/KT3.md
+++ b/content/jailbreaking/Legacy/Popcorn/KT3.md
@@ -29,7 +29,7 @@ On Windows, simply locate the folder you extracted earlier, double click on `MFG
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Linux
 On Linux, open a new terminal and navigate to the folder which contains the folder named `imx_usb_loader`
@@ -42,7 +42,7 @@ And wait for it to complete.
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/Popcorn/KV.md
+++ b/content/jailbreaking/Legacy/Popcorn/KV.md
@@ -29,7 +29,7 @@ On Windows, simply locate the folder you extracted earlier, double click on `MFG
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 
 ## Linux
@@ -43,7 +43,7 @@ And wait for it to complete.
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/Popcorn/PW2.md
+++ b/content/jailbreaking/Legacy/Popcorn/PW2.md
@@ -25,7 +25,7 @@ On Windows, simply locate the folder you extracted earlier, double click on `MFG
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 
 ## Linux
@@ -39,7 +39,7 @@ And wait for it to complete.
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/Popcorn/PW3.md
+++ b/content/jailbreaking/Legacy/Popcorn/PW3.md
@@ -25,7 +25,7 @@ On Windows, simply locate the folder you extracted earlier, double click on `MFG
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 
 ## Linux
@@ -39,7 +39,7 @@ And wait for it to complete.
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/WatchThis/__index.md
+++ b/content/jailbreaking/Legacy/WatchThis/__index.md
@@ -66,7 +66,7 @@ slug: index
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-[Post Jailbreak](../../post-jailbreak/){: .button .button-purple}
+[Post Jailbreak](../../post-jailbreak/)
 
 # Troubleshooting
 If you had any issue with the above steps...

--- a/content/jailbreaking/post-jailbreak/_index.md
+++ b/content/jailbreaking/post-jailbreak/_index.md
@@ -11,4 +11,4 @@ Once you have jailbroken your Kindle, there are still some extremely important s
 > [!WARNING]
 > Turn on Airplane mode now so your Kindle doesn't automatically update to latest firmware before applying OTArenamer!
 
-[Setup a hotfix](./setting-up-a-hotfix){: .button .button-purple}
+[Setup a hotfix](./setting-up-a-hotfix)

--- a/content/kindle-os/usermode-boot-process.md
+++ b/content/kindle-os/usermode-boot-process.md
@@ -8,7 +8,7 @@ weight: 1
 The Kindle uses upstart for its usermode boot process.
 
 Below is a diagram generated from all the Kindle's (PW6) upstart services.
-[Fullscreen Version](./upstart-diagram.html){: .button .button-purple }
+[Fullscreen Version](./upstart-diagram.html)
 
 <style>
     .language-mermaid svg {

--- a/content/mesquito/development/getting-started.md
+++ b/content/mesquito/development/getting-started.md
@@ -55,4 +55,4 @@ You can see the `manifest.json` file, the `index.html` payload and the `icon.jpg
 ## Finding an icon
 The app icon can be almost any image format, however, a resolution of `512x512` is recommended as Mesquito is optimized for `square` icons.
 
-[The Manifest File](./the-manifest-file.html){: .button }
+[The Manifest File](./the-manifest-file.html)

--- a/content/mesquito/development/the-manifest-file.md
+++ b/content/mesquito/development/the-manifest-file.md
@@ -62,4 +62,4 @@ For historic reference, previous manifest version numbers were:<br/>
 - Added version keys
 - Added id key
 
-[The Mesquito SDK](./the-mesquito-sdk.html){: .button }
+[The Mesquito SDK](./the-mesquito-sdk.html)


### PR DESCRIPTION
Probably remants from an previous content markup iteration?