### PR TITLE
Add Minimum Available Space Under MRPI Installation (Troubleshooting)

### DIFF
--- a/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
+++ b/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
@@ -87,4 +87,4 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
 - The installation of `Update_KUALBooklet_hotfix_*_install.bin` may fail if there is not enough free space on your Kindle. If you are using the "fill storage" method to block updates, make sure to free up some space before proceeding with these steps.
 - Verify the location of all the folders and files on the Kindle
 - Try copying the `Update_KUALBooklet_hotfix_*_install.bin` file to the root of your Kindle when connected to your PC, and then go to `Settings` > `Update Your Kindle`, then resume from `step 5`
-- Make sure you have at least 150 MB of free space available
+- Make sure you have around `500 MB` of free space available


### PR DESCRIPTION
I added one line under the troubleshoooting section when installing KUAL and MRPI saying you should atleast have 150 MB left since MRPI checks for it and my install failed 3 times before I went to discord searched around and found this out. Would have saved me 30 minutes.