### PR TITLE
Re-writes, re-ordering and re-phrasing

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -105,6 +105,12 @@ params:
             <p>Documentation for homebrew developers</p>
         </a>
 
+    <div class="landing-section buttons">
+        <a class="card" href="jailbreaking/jailbreak-faq.html">
+            <h2 style="color: var(--text-colour) !important;">Jailbreak F.A.Q</h2>
+            <p>Frequently Asked Questions</p>
+        </a>
+
         <a class="card" href="http://discord.kindlemodding.org/">
             <h2 style="color: var(--text-colour) !important;">Discord</h2>
             <p>Join our Discord</p>

--- a/content/firmware-and-flashing/downgrading/__index.md
+++ b/content/firmware-and-flashing/downgrading/__index.md
@@ -8,22 +8,25 @@ slug: index
 
 # Downgrading Your Kindle
 
-> [!WARNING]
-> A jailbroken Kindle is required - You cannot downgrade a Kindle on stock firmware
+<p class="important">
+<strong>Downgrading is only possible on a jailbroken Kindle</strong>
+<p>
 
+<p class="caution">
+Devices updated to firmware version 5.18.1 or later can no longer be downgraded due to Amazon's bootloader hardening.
+</p>
 
 ## Before You Start
 
 - You do this at your own risk
-- You obviously cannot downgrade to a lower firmware than the one your Kindle originally had. You also cannot downgrade with updates marked for other devices different than yours
-- Backup any important data from your Kindle as this process will **wipe** everything in the device
-- [Restore OTA updates](../../jailbreaking/post-jailbreak/disable-ota) (Click on `Restore`)
+- Downgrading to a firmware version lower than the one originally installed on your Kindle is not possible. Aditionally, update files intended for devices different from your own also cannot be used.
+- Enable Airplane mode and [Restore OTA updates](../../jailbreaking/post-jailbreak/disable-ota) (click on `Restore`)
 - Disable USBNetwork (USBMS mode) if you have the USBNetwork extension installed
 
 ## Prerequisites
 - A PC
 - A jailbroken Kindle (using the [Universal Hotfix](../../jailbreaking/post-jailbreak/setting-up-a-hotfix))
-- [Appropriate Update Firmware .bin you want to downgrade](../downloading-updates).
+- [An appropriate firmware .bin file for the version you want to downgrade to](../downloading-updates).
 
 ## Downgrading
 1. Turn on Airplane Mode, disable USBNetwork and enable OTA updates.
@@ -32,27 +35,28 @@ slug: index
 4. Eject and unplug your Kindle.
 5. Navigate your library and click on the "Allow Downgrade" booklet.
 6. Your Kindle will print text on screen for a couple of seconds and will return to the library menu. Downgrading should be enabled now.
-7. Copy the `update_kindle_*.bin` file to your Kindle root directory. <span style="color: #cf4444">**Do not unplug your Kindle**</span>, hold the power button until your device reboots.
+7. Copy the `update_kindle_*.bin` file to your Kindle root directory. <span style="color: #cf4444">**Do not eject or unplug your Kindle**</span>, hold the power button until your device restarts.
 8. Your Kindle will now install the firmware you copied to it.
 
 ## Post-Downgrading
 
-Congratulations! Your Kindle has been downgraded.
+Congratulations! Your Kindle has been downgraded. To keep the jailbreak, you will need to re-do the post-jailbreak instructions:
 
-> [!NOTE]
-> Devices using the Universal Hotfix will need to re-install it and re-run the booklet.
+<p class="note">
+Large jumps in firmware versions might cause your Kindle to display a white screen after downgrading. This can be easily fixed by plugging your Kindle back into your PC, sideload an empty file named <code>DO_FACTORY_RESTORE</code> (without a file extension) into the root directory and force a reboot by holding the power button for 20 or 30 seconds. Make sure to backup your files before doing this
+</p>
 
-> [!NOTE]
-> Large jumps in firmware versions might cause your Kindle to display a white screen after downgrading. This can be easily fixed by plugging your Kindle back into your PC, sideload an empty file named `DO_FACTORY_RESTORE` (without extension) into the root directory and force a reboot by holding the power button for 20 or 30 seconds.
+<p class="important">
+Extension compatibility differs between hard-float (>=5.16.3) and soft-float (<=5.16.2.1.1) firmware. Downgrading to soft-float firmware or viceversa may cause some extensions to stop working
+</p>
 
-> [!NOTE]
-> Keep in mind that not every extension out there was not made for hard float firmware (`>=5.16.3`) or soft float firmware (`<=5.16.2.1.1`), if you make a jump between those two updates, make sure you're installing the correct packages and extensions.
+<p class="note">
+Some devices may let you skip the initial device set-up by simply restarting the device, but some others will keep prompting the set-up. In this case, do sign in but skip the Wi-Fi prompt, then delete the <code>update.bin.tmp.partial</code> file located in your Kindle root directory if present
+</p>
 
-> [!INFO]
-> Some devices may let you skip the initial device set-up by simply restarting the device. But if your device keeps prompting the set-up, do it quickly (skipping Wi-Fi), and then delete the partial OTA download located in your Kindle root directory.
-
-
-After downgrading, you will need to re-do the post-jailbreak instructions:
+<p class="tip">
+If you notice a <strong>significantly</strong> slower performance after the downgrade, it is recommended to perform a factory reset. Don't forget to backup your files and setting up the hotfix first
+</p>
 
 <a class="button" href="../../jailbreaking/post-jailbreak/setting-up-a-hotfix/">Setting Up A Hotfix</a>
 

--- a/content/jailbreaking/Legacy/LanguageBreak.md
+++ b/content/jailbreaking/Legacy/LanguageBreak.md
@@ -32,7 +32,7 @@ weight: 1
 4. Type `;enter_demo` into the Kindle's searchbar an click enter
 5. Reboot the Kindle by holding down the button and selecting the `reboot` option when it appears
 6. The device should now boot into demo mode, if it doesn't, check the [Troubleshooting](#troubleshooting) section
-7. Skip WiFi setup and enter fake information when prompted
+7. Skip Wi-Fi setup and enter fake information when prompted
 8. Skip searching for a demo payload
 9. Select the `standard` demo type
 10. Press `Done` at the "sideload content" prompt

--- a/content/jailbreaking/Legacy/WatchThis/__index.md
+++ b/content/jailbreaking/Legacy/WatchThis/__index.md
@@ -24,7 +24,7 @@ slug: index
 4. Type `;enter_demo` into the Kindle's searchbar an click enter
 5. Reboot the Kindle by holding down the button and selecting the `reboot` option when it appears
 6. The device should now boot into demo mode, if it doesn't, check the [Troubleshooting](#troubleshooting) section
-7. Skip WiFi setup and enter fake information when prompted
+7. Skip Wi-Fi setup and enter fake information when prompted
 8. Skip searching for a demo payload
 9. Select the `standard` demo type
 10. Press `Done` at the "sideload content" prompt

--- a/content/jailbreaking/WinterBreak/__index.md
+++ b/content/jailbreaking/WinterBreak/__index.md
@@ -28,8 +28,8 @@ It is based on [Mesquito](../../mesquito/)
 ## Prerequisites
 - You will need a PC
 - Your Kindle must be registered
-- Your Kindle must have a valid, internet-connected WiFi network saved to it that it can connect to during steps 5 to 7 (inclusive)
-- Your Kindle's storage must be almost full, with only 20-90 MB of free space remaining to avoid automatic updates
+- Your Kindle must have a valid, internet-connected Wi-Fi network saved that it can connect to during steps 5–7 (inclusive)
+- Your Kindle's storage must be almost full, with only 50-90 MB of free space remaining to [avoid automatic updates](../prevent-auto-update/)
 - File archiver software to unzip files ([7-zip](https://www.7-zip.org/) or [WinRar](https://www.win-rar.com/start.html?&L=0) for Windows)
 
 > [!INFO]
@@ -126,17 +126,17 @@ If an **“Unexpected error”** occurs when you try to log in to the Kindle Sto
 
 ### LocalStorage Replacement
 
-1. After successfully registered, plug your Kindle into your PC and delete the `.active_content_sandbox` folder,  make sure to also delete any files with a name similar to `update.bin.tmp.partial` from your Kindle to prevent an automatic update
+1. After successfully **registering and filling the Kindle's storage**, plug your Kindle into your PC and delete the `.active_content_sandbox` folder.
 2. Reboot your Kindle
-3. Disable Airplane mode and connect to a WiFi connection
-4. Browse the regular Kindle Store for a couple of minutes to generate the files needed for Winterbreak to work, browse the book categories and download a free sample of any book
-5. After a couple of minutes, enable Airplane mode and plug your Kindle into your PC again
-6. Delete the cache directory in the path `.active_content_sandbox/store/resource/LocalStorage`. If this folder has not yet been generated, browse the Kindle Store for another couple of minutes until it is generated. Make sure to always delete the previously mentioned `update.bin.tmp.partial` file, especially before any rebooting
-7. Once deleted, copy the Winterbreak files to your Kindle and reboot
+3. Disable Airplane mode and connect to a Wi-Fi connection
+4. Browse the regular Kindle Store for a couple of minutes to generate the files needed for Winterbreak, browse the book categories and download a free sample of any book
+5. Enable Airplane mode and plug your Kindle into your PC again
+6. Delete the cache directory in the path `.active_content_sandbox/store/resource/LocalStorage`. If this folder has not yet been generated, browse the Kindle Store for another couple of minutes until it is generated.
+7. Once deleted, copy the Winterbreak files to your Kindle, delete any stray `update-bin-whatever.bin` file and reboot
 8. Open the Kindle Store on your Kindle, when prompted, click `Yes` to turn off Airplane mode
 
 ### Factory Reset
-> Faced this error and found a solution [DiabloSat](https://github.com/progzone122) & [Rexathion1](https://github.com/Rexathion1)
+> Solution by: [DiabloSat](https://github.com/progzone122) & [Rexathion1](https://github.com/Rexathion1)
 
 1. Factory Reset your Kindle
 2. Before registering - plug your Kindle into your PC, move the WinterBreak files to the root of your storage space

--- a/content/jailbreaking/WinterBreak/__index.md
+++ b/content/jailbreaking/WinterBreak/__index.md
@@ -132,7 +132,7 @@ If an **“Unexpected error”** occurs when you try to log in to the Kindle Sto
 4. Browse the regular Kindle Store for a couple of minutes to generate the files needed for Winterbreak, browse the book categories and download a free sample of any book
 5. Enable Airplane mode and plug your Kindle into your PC again
 6. Delete the cache directory in the path `.active_content_sandbox/store/resource/LocalStorage`. If this folder has not yet been generated, browse the Kindle Store for another couple of minutes until it is generated.
-7. Once deleted, copy the Winterbreak files to your Kindle, delete any stray `update-bin-whatever.bin` file and reboot
+7. Once deleted, copy the Winterbreak files to your Kindle, delete any stray `update-bin-whatever.bin` or `update.bin.tmp.partial` files and reboot
 8. Open the Kindle Store on your Kindle, when prompted, click `Yes` to turn off Airplane mode
 
 ### Factory Reset

--- a/content/jailbreaking/_index.md
+++ b/content/jailbreaking/_index.md
@@ -26,7 +26,7 @@ As a user, this gives you access to:
 Always jailbreak at your own risk.
 If you don't know what you are doing or are unsure, don't do it.
 
-[Getting Started](../kindle-models.html)
+<a href="../kindle-models.html" class="button">Getting Started...</a><br/>
 
 ## Credits
 Parts of this page were adapted from [Reddit](https://www.reddit.com/r/kindle/comments/1hrwytr/comment/m516ft5/)

--- a/content/jailbreaking/jailbreak-faq.md
+++ b/content/jailbreaking/jailbreak-faq.md
@@ -9,17 +9,12 @@ weight: 98
 
 We recommend reading this article before or after jailbreaking your Kindle device and share it with other people.
 
-> [!NOTE]
-> Most of these instructions are subjected to changes due to newer jailbreaks, patches, extensions, firmware versions, etc. <br>`(Last updated: Aug 28, 2025)`
+<p class="important">
+Most of these instructions are subjected to changes due to newer jailbreaks, patches, extensions, firmware versions, etc. <br><code>(Last updated: Apr 09, 2026)</code>
+</p>
 
 ## General/Account
 ---
-
-### Can I jailbreak my Kindle with Winterbreak if my device is unregistered/blacklisted?
-
-Winterbreak needs your Kindle to be registered, it also needs a valid, internet-connected WiFi network saved.
-
-It's still possible to jailbreak an unregistered/blacklisted device, but currently, the only jailbreaking methods for those devices work on or below firmware `5.16.2.1.1`. You can find these jailbreaking methods in [Legacy Jailbreaks](https://kindlemodding.org/jailbreaking/Legacy/).
 
 ### My Kindle updated to a firmware version that doesn't have any jailbreak method! Can I still jailbreak it?
 
@@ -35,20 +30,25 @@ If you still want to use the internet on your Kindle while avoiding automatic up
 
 Your Kindle must be jailbroken first in order to downgrade. This is because Amazon has never provided a way to downgrade on stock firmware.
 
-### Can I remove my account after jailbreaking?
+### Can I jailbreak my Kindle if my device is unregistered/blacklisted?
 
-Yes, but for Winterbreak, you will have to log in again if you want to jailbreak from scratch. Your Kindle will remain jailbroken whether you log back in or log out.
+[Nosebleed Jailbreak](../jailbreaking/Nosebleed) reportedly, works for some blacklisted devices.
 
-> [!INFO]
-> After unregistering, the Kindle will delete all files located in the documents folder, including the KUAL Launcher booklet and any other scripts that have been transferred. Be sure to back up these files first.
+For devices on firmware `5.16.2.1.1` or below, you can try any of the jailbreaking methods listed in [Legacy Jailbreaks](../jailbreaking/Legacy/).
+
+### Can I deregister my Kindle after jailbreaking?
+
+Yes, your Kindle will remain jailbroken whether you log back in or log out.
+
+However, deregistering will delete all files within the documents folder, including the KUAL launcher booklet and any other scriplets transferred to the device, which may partially break extensions. Be sure to back up all your files first.
 
 ### Can I un-jailbreak my Kindle?
 
-Yes, re-enable automatic updates first (`Restore` option in `renametobin`) to avoid an update block. Then, perform a factory reset on the device and install the same firmware update (or a higher version). 
+Yes, re-enable automatic updates first (`Restore` option in `renametobin`) to avoid an update block. Then, perform a factory reset on the device and install the same firmware update (or any higher version).
 
 ### Will the jailbreak get my Amazon account banned?
 
-No reports of Amazon accounts being banned after jailbreaking have been reported so far. However, please refrain from telling support that you have modified your device.
+No reports of Amazon accounts being banned after jailbreaking have been reported so far. However, **please refrain** from telling support that you have modified your device.
 
 ### Will this void the warranty on my Kindle device?
 Probably.
@@ -80,8 +80,10 @@ Yes.
 
 No.
 
-> [!NOTE]
-> If your device has been in Airplane mode for a long period of time, there is a possibility that [Amazon will delete all sideloaded books](https://www.mobileread.com/forums/showpost.php?p=4419300&postcount=409) from your device after reconnecting to WiFi due to an internal book tag. This can happen regardless of whether your device is jailbroken or not. Backup your books whenever you can
+<p class="warning">
+If your device has been in Airplane mode for a long period of time, there is a possibility that <a href="https://www.mobileread.com/forums/showpost.php?p=4419300&postcount=409">Amazon will delete all sideloaded books</a> from your device after reconnecting to Wi-Fi due to an internal book tag. This can happen regardless of whether your device is jailbroken or not. Backup your books whenever you can
+
+</p>
 
 ### Will Libby/Readwise/GoodReads/Kindle Unlimited/Send To Kindle still work after jailbreaking?
 
@@ -126,7 +128,7 @@ Not necessarily.
 
 You can launch it with simple [scriptlets](https://kindlemodding.org/kindle-dev/scriptlets.html), specifically, Marek's launcher that is available [here](https://scriptlets.notmarek.com/).
 
-A [KUAL booklet launcher (made by yparitcher)](https://github.com/yparitcher/KUAL_Booklet/releases/) extension is also available to install. You can further customize both the KUAL booklet and the KOR launcher with the [coversetter extension made by Stanner](https://www.mobileread.com/forums/showpost.php?p=4222466&postcount=15).
+[KOR booklet launcher (made by yparitcher)](https://github.com/yparitcher/KUAL_Booklet/releases/) is also available to install. You can further customize both the KUAL booklet and the KOReader launcher with the [coversetter extension made by Stanner](https://www.mobileread.com/forums/showpost.php?p=4222466&postcount=15).
 
 ## Technical
 ---
@@ -143,16 +145,17 @@ Yes, but you must first enable Airplane mode and enable automatic updates again 
 
 When updating, ensure that the newer version supports a jailbreak.
 
-> [!INFO]
-> After updating/factory reset/downgrading, re-install the hotfix from scratch. KUAL and some others extensions *may* need to be re-installed too.
+<p class="note">
+After updating/factory reset/downgrading, reinstall the hotfix from scratch. KUAL and some others extensions <strong>may</strong> need to be reinstalled too.
+</p>
 
 ### How do I downgrade my Kindle?
 
-[Read and follow this guide](https://kindlemodding.org/firmware-and-flashing/downgrading/#downgrading-your-kindle).
+[Read and follow this guide](../firmware-and-flashing/downgrading/#downgrading-your-kindle).
 
 ### Where can I download firmware update files?
 
-[Read and follow this guide](https://kindlemodding.org/firmware-and-flashing/downloading-updates.html).
+[Read and follow this guide](../firmware-and-flashing/downloading-updates.html).
 
 Find your exact model, find the download link and re-type the numbers to get the firmware version you want.
 
@@ -166,17 +169,16 @@ Download the "Check OTA Status" scriptlet from [here](https://scriptlets.notmare
 
 ### Is it possible to change screensavers in the native Kindle UI?
 
-Although there are currently no extensions to change the screensavers in hard-float firmware, it is still possible to change them, but it is not recommended as it is very easy to brick the device.
+There are currently no extensions to change the screensavers in hard-float firmware. If you're running on soft-float firmware it is still possible to change them with the [NiLuJe's screensaver hack](https://www.mobileread.com/forums/showthread.php?t=195474). Keep in mind that this extension may not work on some final soft-float firmware versions.
 
-If you still want to change the screensavers, check the details of your default Kindle screensavers inside the `/usr/share/blanket/screensavers` folder, get root writing permissions, and set the custom ones with the same name prefix and settings (bit-depth and resolution). You can either replace them all or add them to the slideshow queue.
+<p class="caution">
+<strong>Please do not make the mistake of installing this extension under hard-float firmware</strong>
 
-Please note that even after following these precautions, it is not guaranteed your device won’t brick, especially if you're using GIMP to export the images.
+</p>
 
-> [!INFO]
-> If you are, however, running soft-float firmware prior to or on 5.16.2.1.1 you can install [NiLuJe's screensaver hack](https://www.mobileread.com/forums/showthread.php?t=195474). **Please do not make the mistake of installing this extension on hard-float firmware.**
-
-> [!NOTE]
-> You can easily change screensavers with [KOReader](https://koreader.rocks/user_guide/) (search for the "screensavers" feature).
+<p class="note">
+You can easily change screensavers with <a href="https://koreader.rocks/user_guide/">KOReader</a> (search for the "screensavers" feature)
+</p>
 
 ## Jailbreaking
 ---
@@ -188,7 +190,7 @@ Type `;log` into the search bar, if a message pop ups, you're jailbroken.
 ### KUAL stopped working!/I can't no longer launch any of my extensions!
 Verify if your device is still jailbroken by typing `;log` into the search bar.
 
-- If it prompted any text, [re-install the hotfix and KUAL](https://kindlemodding.org/jailbreaking/post-jailbreak/setting-up-a-hotfix/) from scratch.
+- If it prompted any text, [reinstall the hotfix and KUAL](https://kindlemodding.org/jailbreaking/post-jailbreak/setting-up-a-hotfix/) from scratch.
 - If not [re-jailbreak](https://kindlemodding.org/kindle-models) your device.
 - If everything else failed, factory reset your device and start the jailbreak from scratch. 
 
@@ -204,8 +206,9 @@ This is expected, you can safely reboot your device manually (holding the power 
 
 If you're using Winterbreak, unless the Kindle displays the message "You are now ready to install the hotfix" in small text, you can safely continue with the post-jailbreak instructions . If it doesn't, something went wrong during the jailbreak process, and you'll have to try again.
 
-> [!INFO]
-> Remember to delete any automatic update file that might have appeared.
+<p class="important">
+Remember to delete any automatic update file that might have appeared.
+</p>
 
 ### I kept getting random "KPPMainAppV2" books added to my Kindle library, what should I do!?
 
@@ -219,7 +222,9 @@ You can do one of the following:
 
 - [Install KOReader](https://kindlemodding.org/jailbreaking/post-jailbreak/koreader.html)
 - [Downgrade your Kindle](https://kindlemodding.org/firmware-and-flashing/downgrading/)
-- [Download some scriptlets](https://scriptlets.notmarek.com/)
+- Download scriptlets:
+    - [Marek's Scriplets](https://scriptlets.notmarek.com/)
+    - [Kindle Modding Tools & Resources](https://kindlemodshelf.me/)
 - [Develop more extensions](https://kindlemodding.org/kindle-dev/) 
 - Browse [MobileRead](https://www.mobileread.com/forums/forumdisplay.php?f=150) or the Kindle Modding Community Discord Server for more scriplets and extensions.
 - Install Alpine Linux

--- a/content/jailbreaking/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/post-jailbreak/disable-ota.md
@@ -7,7 +7,7 @@ weight: 3
 
 # Disabling OTA Updates
 
-Kindles automatically update when connected to WiFi, which despite a `hotfix`, can often cause instabilities on jailbroken systems or outright remove the jailbreak.
+Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, can often cause instabilities on jailbroken systems or outright remove the jailbreak.
 
 <div id="guide">
     <div class="buttons">
@@ -118,7 +118,7 @@ Kindles automatically update when connected to WiFi, which despite a `hotfix`, c
                     <p class="version-label">Firmware >=5.11.x:</p>
                     <p>If you want to factory reset, downgrade or update your Kindle, you will <strong>need</strong> to restore the update binaries by opening KUAL, selecting <code>Rename OTA Binaries</code> and then selecting <code>Restore</code> instead of rename</p>
                 </div>
-                <p class="highlight">You can now safely turn off Airplane Mode and re-enable WiFi. Your Kindle will connect to the internet but will not download or install OTA updates.</p>
+                <p class="highlight">You can now safely turn off Airplane Mode and re-enable Wi-Fi. Your Kindle will connect to the internet but will not download or install OTA updates.</p>
             </div>
         </div>
     </div>

--- a/content/jailbreaking/post-jailbreak/setting-up-a-hotfix/__index.md
+++ b/content/jailbreaking/post-jailbreak/setting-up-a-hotfix/__index.md
@@ -10,7 +10,7 @@ slug: index
 A hotfix allows your Kindle's jailbreak to persist after updating. There are two different hotfixes and which one you need to install depends on which method you used to jailbreak your Kindle.
 
 > [!INFO]
-> If you installed OTARenamer, make sure to uninstall it beforehand or the hotfix will not be detected by the Kindle
+> If you have blocked the updates using `renametobin` (set to `Rename`), make sure to revert it beforehand (by selecting `Restore`), or you will not be able to install the hotfix through the Settings menu
 
 <div id="guide">
     <div class="buttons">
@@ -25,7 +25,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
                 <a href="https://github.com/KindleModding/Hotfix/releases/latest/download/Update_hotfix_universal.bin" class="button">Download</a>
                 <br/>
                 <p class="warning">
-                    If scriptlets don't work, please redo these steps using the <b>compatibility hotfix!</b>
+                    If scriptlets don't work, please re-do these steps using the <b>compatibility hotfix!</b>
                 </p>
             </div>
         </div>

--- a/content/jailbreaking/prevent-auto-update/__index.md
+++ b/content/jailbreaking/prevent-auto-update/__index.md
@@ -17,7 +17,7 @@ Kindle devices can automatically download and install firmware updates when they
 - The device is connected to Wi-Fi, even briefly.
 - The Kindle is rebooted while connected to the internet.
 
-Filling the Kindle's storage (leaving only 20-90 MB free) prevents the device from downloading and installing updates, as the update process requires more free space.
+Filling the Kindle's storage (leaving only 50-90 MB free) prevents the device from downloading and installing updates, as the update process requires more free space.
 
 ## How to Fill the Kindle's Storage
 
@@ -26,12 +26,10 @@ Filling the Kindle's storage (leaving only 20-90 MB free) prevents the device fr
 
 You can use a simple script to fill your Kindle's storage with dummy files, leaving only a small amount of free space. This script is available in the [Kindle-Filler-Disk GitHub repository](https://github.com/bastianmarin/Kindle-Filler-Disk/) along with other useful scripts for Windows, macOS, and Linux.
 
-> [!NOTE]
-> The script will not work on 11th gen Kindles and newer because these devices use MTP to connect to computers
-
-> If this is your situation, you have two options:
-> 1. Delete any stray files ending in <code>.bin</code>, or have a similar name to <code>update.bin.tmp.partial</code> manually at every step of the Jailbreak guide (or before doing any rebooting)
-> 2. Manually fill your Kindle. Download the [Filler files](https://github.com/bastianmarin/Kindle-Filler-Disk/tree/main/MTP/) that match your Kindle's storage from the link below. Extract the files, then move them to the root of your Kindle (you can also save them on a separate folder). After doing so, make sure to leave only 20–90 MB of free space
+> [!WARNING]
+> This script will not work on 11th generation Kindles and newer, as these devices use MTP (Media Transfer Protocol) instead of standard USB storage when connected to a computer
+>
+> You will need to manually fill your Kindle with "dummy" files. Download the [Filler files](https://github.com/bastianmarin/Kindle-Filler-Disk/tree/main/MTP/) that match your Kindle's storage from the link below. Extract the files, then move them to the root of your Kindle (you can also save them on a separate folder). After doing so, make sure to leave only 50–90 MB of free space
 
 <div id="guide">
     <div class="buttons">
@@ -102,23 +100,18 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <div class="stepContent">
                 <p>Eject your Kindle from your computer.</p>
                 <p>On your Kindle, go to <strong>Settings &gt; Device Options &gt; Device Info</strong> (or similar).</p>
-                <p>Check that the available storage is <strong>20-90 MB or less</strong>.</p>
+                <p>Check that the available storage is <strong>50-90 MB or less</strong>.</p>
                 <img src="./final.png"/>
             </div>
-        </div>
+        </div>     
         <div class="step">
-            <h2>7. Register Your Kindle</h2>
+            <h2>7. Continue with Jailbreak</h2>
             <div class="stepContent">
-                <p>With storage nearly full, connect to Wi-Fi and register your Kindle to your Amazon account. The device will not be able to download updates due to lack of space.</p>
-            </div>
-        </div>
-        <div class="step">
-            <h2>8. Enable Airplane Mode Again</h2>
-            <div class="stepContent">
-                <p>Immediately after registration, enable <strong>Airplane Mode</strong> to prevent any update attempts.</p>
-                <p>Proceed with the next jailbreak steps (such as WinterBreak).</p>
-                <p class="highlight">
-                    <strong>Important Note:</strong> After filling your Kindle's storage, check its contents in the <strong>main folder</strong> (root directory) and delete any files ending with <code>.bin</code> or named <code>update.bin.tmp.partial</code>. These files are automatic update attempts by the Kindle and should be removed to prevent the device from trying to install an update when you free up space.
+                <p>With storage nearly full, you can now connect to Wi-Fi and register your Kindle to your Amazon account.</p> 
+                <p>The Kindle will not be able to fully download the update due to a lack of space.</p>
+                <p>You can either perform a <a href="/kindle-models.html">Jailbreak suitable for your device</a> or wait for the next jailbreak to be released.</p> 
+                <p class="info">
+                  Always make sure to delete any files ending with <code>.bin</code> or named <code>update.bin.tmp.partial</code>
                 </p>
             </div>
         </div>

--- a/content/jailbreaking/recovering-from-a-reset.md
+++ b/content/jailbreaking/recovering-from-a-reset.md
@@ -1,16 +1,21 @@
 ---
 layout: default
 parent: Jailbreaking Your Kindle
-title: Recovering From A Reset
+title: Recovering From a Reset
 weight: 99
 ---
 
-# Recovering From A Reset
-If you reset your Kindle in a jailbroken state with `renametobin` left enabled, your Kindle may be in a locked state, to fix this, perform the following steps:
+# Recovering From a Reset
+Factory resetting a jailbroken Kindle with renametobin (`Rename`) left enabled will make it impossible to install either the hotfix or official update files. To fix this, follow these steps:
 
 1. Follow the [MRPI installation instructions](./post-jailbreak/installing-kual-mrpi/)
 2. Follow the [Disable OTA instructions](./post-jailbreak/disable-ota.html)
 3. Instead of choosing the `Rename` option, use the `Restore` option
 
-> [!NOTE]
-> If you come from an un-jailbreak attempt, you can also force an update by copying the firmware update file to your Kindle and, while still plugged in, hold down the power button until it restarts.
+<p class="note">
+If you come from an un-jailbreak attempt, you can also force an update by copying the firmware update file to your Kindle and, while still plugged in, hold down the power button until it restarts
+</p>
+
+<p class="caution">
+    Remember that performing a factory reset followed by an update will remove any jailbreak remnants
+</p>


### PR DESCRIPTION
- Added a button for the FAQ on the first page of the website
- Downgrading page
    - Re-wrote a couple of things on the downgrading page, added a warning for the 5.18 firmware versions no longer being down-gradable, 
    - Streamlined the pre-requisites, the instructions and the info boxes
    - Also rewrote the previously confusing statement about soft float and hard float)
    - Removed the fact that you needed to back up your files before downgrading, expanded more on this in the last info box
- Corrected the word WiFi to Wi-Fi in a couple of articles
- Corrected the word re-install to reinstall in a couple of other articles 
- Made a prerequisite on the winterbreak article and a couple of instructions on the troubleshooting section of the same article a little bit clearer 
- Added a button for "getting started" on the jailbreak index page for a nicer look
- Re-ordering, re-phrasing and updates on the FAQ page
	- Included a mention to the nosebleed jailbreak for the blacklisted question
	- Most important one is the deletion of the mention in how to replace screensavers in hard float firmware for the safety of new users also because they would rather do it on KOReader
	- Added kindlemodshelf to the list of websites at the end of the FAQ article
- Expanded a little bit more on the first warning written on the renametobin article (having otarenamer instead of renametobin might tip off some new users, might be better to remove this warning at all and redirect people to the recovering from a reset page?)
- Prevent update page 
	- Expanded more on the 11th gen and mtp part, I think there's a MTP article ready to be merged? I don't know if we should include another fluent box for it, maybe make two pages for each?
	- Also changed the recommended free space from 20-50 to 20-90 might up the 20 prerequisite some time later but I think it's fine for now
	- Removed the step 8 because it could be read as redundant also because one user in the discord thought the kindle had to be registered first before filling storage, rewrote the last fluent box to be more inclusive considering that filling the storage pretty much makes the device safer than anything from updates
- Re-wrote the recovering from a reset article because it felt like a stub
