### PR TITLE
Add 'Update_KUALBooklet_HDRepack.bin' filename to the install KUAL instructions

### DIFF
--- a/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
+++ b/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
@@ -48,7 +48,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
             <div class="stepContent">
             <p class="note">If your device is older than the K5 (Kindle Touch), you only need to copy the <code>KUAL-KDK-1.0.azw2</code> file to your Kindle's <code>documents</code> folder, you can skip the next steps</p>
             <p class="important">If you downloaded KUAL for <strong>legacy devices</strong>, extract the .tar.xz to get the <code>Update_KUALBooklet_*_install.bin</code> file</p>
-            <p>Copy the <code>Update_KUALBooklet_*_install.bin</code> file to your Kindle's <code>mrpackages</code> folder</p>
+            <p>Copy the <code>Update_KUALBooklet_HDRepack.bin</code> file (if you chose KUAL Coplate for Kindles newer than the K5) or the <code>Update_KUALBooklet_*_install.bin</code> file (for legacy devices) to your Kindle's <code>mrpackages</code> folder</p>
                 <br/>
                 <img src="./kual_install_bin.png" />
             </div>


### PR DESCRIPTION
First of all a big thank you to all contributors of this wiki.
Everything about jail-breaking my Kindle Paperwhite 2 has been a smooth "it just works"™ experience so far.

The only time i got confused during the process was in the [Installing KUAL MRPI](https://kindlemodding.org/jailbreaking/post-jailbreak/installing-kual-mrpi) instructions.
After downloading the KUAL Coplate install binary file for devices newer than the K5 (`Update_KUALBooklet_HDRepack.bin`), i noticed that this filename was not mentioned in the `Extracting/Copying KUAL` section.

The only two filenames mentioned in that section are `KUAL-KDK-1.0.azw2`and `Update_KUALBooklet_*_install.bin`.

This PR adds the `Update_KUALBooklet_HDRepack.bin` filename, along with a short explanation for what filename is from what version.