### PR TITLE
Add post-jailbreak mod resources page

### DIFF
--- a/content/jailbreaking/post-jailbreak/koreader.md
+++ b/content/jailbreaking/post-jailbreak/koreader.md
@@ -114,7 +114,7 @@ _KOReader is a document viewer for E Ink devices. Supported formats include EPUB
     </div>
 </div>
 
-<script>new Guide("guide", "../jailbreak-faq.html", "Jailbreak FAQ");</script>
+<script>new Guide("guide", "what-else.html", "What Else?");</script>
 
 ## Credits
 

--- a/content/jailbreaking/post-jailbreak/what-else.md
+++ b/content/jailbreaking/post-jailbreak/what-else.md
@@ -1,0 +1,49 @@
+---
+layout: default
+parent: Post Jailbreak
+title: What Else?
+weight: 6
+---
+
+# What Else?
+
+Once you have finished the post-jailbreak setup, your Kindle can run more than just KOReader. There are mods for reading, music playback, audiobooks, terminals, launchers, games, emulators, KOReader plugins, patches, system tweaks, and other homebrew tools.
+
+<div id="guide">
+    <div class="buttons">
+        <button id="prev">Previous Step</button>
+        <span id="stepCounter"></span>
+        <button id="next">Next Step</button>
+    </div>
+    <div id="stepwrapper" class="stepwrapper">
+        <div class="step">
+            <h2>KindleForge App Store</h2>
+            <div class="stepContent">
+                <div class="version-block">
+                    <p class="version-label">Easy app installation</p>
+                    <p>KindleForge is the easiest way to install a select set of Kindle apps and tweaks directly from your jailbroken Kindle.</p>
+                    <p>Use it when you want an on-device app store instead of manually downloading, extracting, and copying every app yourself.</p>
+                    <a class="button" href="https://github.com/KindleTweaks/KindleForge" target="_blank">Check Out KindleForge</a>
+                </div>
+            </div>
+        </div>
+        <div class="step">
+            <h2>KindleModShelf</h2>
+            <div class="stepContent">
+                <div class="version-block">
+                    <p class="version-label">Everything modding hub</p>
+                    <p>KindleModShelf is a nicely formatted directory for the wider Kindle modding scene, including apps, KOReader plugins, patches, games, tools, and guides.</p>
+                    <p>Use it when you want to browse everything available, including many projects that are not installable through KindleForge.</p>
+                    <a class="button" href="https://kindlemodshelf.me/" target="_blank">Browse KindleModShelf</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="buttons">
+        <button id="prev">Previous Step</button>
+        <span id="stepCounter"></span>
+        <button id="next">Next Step</button>
+    </div>
+</div>
+
+<script>new Guide("guide", "../jailbreak-faq.html", "Jailbreak FAQ");</script>


### PR DESCRIPTION
Adds a What Else page after the KOReader guide with links to KindleForge and KindleModShelf.