### PR TITLE
Updated the URL for the filler files on Preventing Automatic Updates by Filling Kindle Storage

### DIFF
--- a/content/jailbreaking/prevent-auto-update/__index.md
+++ b/content/jailbreaking/prevent-auto-update/__index.md
@@ -29,7 +29,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
 > [!WARNING]
 > This script will not work on 11th generation Kindles and newer, as these devices use MTP (Media Transfer Protocol) instead of standard USB storage when connected to a computer
 >
-> You will need to manually fill your Kindle with "dummy" files. Download the [Filler files](https://github.com/bastianmarin/Kindle-Filler-Disk/tree/main/MTP/) that match your Kindle's storage from the link below. Extract the files, then move them to the root of your Kindle (you can also save them on a separate folder). After doing so, make sure to leave only 50–90 MB of free space
+> You will need to manually fill your Kindle with "dummy" files. Download the [Filler files](https://github.com/Crosunt223/Kindle-Filler-Disk/tree/main/MTP) that match your Kindle's storage from the link below. Extract the files, then move them to the root of your Kindle (you can also save them on a separate folder). After doing so, make sure to leave only 50–90 MB of free space
 
 <div id="guide">
     <div class="buttons">


### PR DESCRIPTION
The link to the filler files on the `Preventing Automatic Updates by Filling Kindle Storage` page no longer links to the files. Updated the link to another fork's version to allow continued use.

This should resolve issue #161 