### PR TITLE
Stress airplane-mode reminder before post-jailbreak and KUAL/MRPI

### DIFF
--- a/content/jailbreaking/AdBreak/__index.md
+++ b/content/jailbreaking/AdBreak/__index.md
@@ -111,6 +111,7 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
                 <p class="note">
                     You can safely ignore any "application error" popups, they are irrelevant.
                 </p>
+                <p class="warning"><b>Ensure Airplane mode is still enabled</b> (turn it back on if it's off) before continuing to the post-jailbreak stage, to prevent an automatic update.</p>
                 <img src="./demo.png" />
             </div>
         </div>

--- a/content/jailbreaking/Nosebleed/__index.md
+++ b/content/jailbreaking/Nosebleed/__index.md
@@ -79,6 +79,16 @@ Nosebleed is a jailbreak released on 02/03/2026 by hhhhhhhhh.
                 <img src="./jailbreak.png" />
             </div>
         </div>
+        <div class="step">
+            <h2>Done</h2>
+            <div class="stepContent">
+                <p>Once the jailbreak has completed, continue to the post-jailbreak stage.</p>
+                <p class="warning"><b>Turn Airplane mode on now</b> to prevent your Kindle from automatically updating before blocking OTA updates.</p>
+                <p class="warning">
+                    If present, delete the <code>update.bin.tmp.partial</code> file from your device to prevent an automatic update
+                </p>
+            </div>
+        </div>
     </div>
     <div class="buttons">
         <button id="prev">Previous Step</button>

--- a/content/jailbreaking/WinterBreak/__index.md
+++ b/content/jailbreaking/WinterBreak/__index.md
@@ -106,7 +106,9 @@ It is based on [Mesquito](../../mesquito/)
             <h2>Done</h2>
             <div class="stepContent">
                 <p>Wait around 30 seconds, and your Kindle will say something along the lines of "Now you are ready to install the hotfix"</p>
-                <p>If no funky text appears, retry the guide again. Once it does, <b>turn Airplane mode back on</b> and continue to the post-jailbreak stage
+                <p>If no funky text appears, retry the guide again.</p>
+                <p class="warning">
+                    Once it does, <b>turn Airplane mode back on</b> before continuing to the post-jailbreak stage, to prevent an automatic update.
                 </p>
                 <p class="warning">
                     If present, delete the <code>update.bin.tmp.partial</code> file from your device to prevent an automatic update

--- a/content/jailbreaking/WinterBreak2/__index.md
+++ b/content/jailbreaking/WinterBreak2/__index.md
@@ -96,7 +96,9 @@ Unlike WinterBreak, WinterBreak2 uses the Kindle's built-in Experimental Browser
         <div class="step">
             <h2>Done</h2>
             <div class="stepContent">
-                <p>Once the jailbreak has completed, <b>turn Airplane mode on</b> and continue to the post-jailbreak stage</p>
+                <p class="warning">
+                    Once the jailbreak has completed, <b>turn Airplane mode on</b> before continuing to the post-jailbreak stage, to prevent an automatic update.
+                </p>
                 <p class="warning">
                     If present, delete the <code>update.bin.tmp.partial</code> file from your device to prevent an automatic update
                 </p>

--- a/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
+++ b/content/jailbreaking/post-jailbreak/installing-kual-mrpi/__index.md
@@ -23,6 +23,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
                 <p>This version of MRPI is provided by <a href="https://fw.notmarek.com/khf/">Marek</a></p>
                 <a class="button" href="./kual-mrinstaller-1.7.N-r19303.zip">MRPI (for legacy devices - pre-K5)</a>
                 <p class="important">You may need to free up 220 MB of space to install both MRPI and KUAL <a href="#troubleshooting">without issues</a></p>
+                <p class="warning"><b>Make sure Airplane mode is on before freeing up this space.</b> If it isn't, your Kindle may use the freed space to download and install an OTA update.</p>
             </div>
         </div>
         <div class="step">


### PR DESCRIPTION
I've observed that the most common point of failure for "oops I got updated" seems to be between installing the hotfix and installing KUAL, which points to people not enabling airplane mode before freeing up the requisite space.  I noticed that the "Post Jailbreak" index page _does_ include a warning to enable airplane mode, but this page exists outside of the stepwise flow, and is therefore never actually hit by following the "next step" flow of any of the guides.

This PR adds explicit instructions to the final step of applicable JB guides (or emphasizes them, for the ones that already mentioned it) to ensure airplane mode is enabled before proceeding, and adds a specific warning to the KUAL/MRPI instructions as well for additional insurance.